### PR TITLE
add GA4 to Jekyll head template

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-KNYEBYGTV8"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-KNYEBYGTV8');
+</script>


### PR DESCRIPTION
To enable Google Analytics to track the doc links, we add a `head-custom.html` file to the `docs/_includes` folder , this file contains the Google Analytics tag. When Jekyll builds the html files from Markdown ones, they will contain the GA tag.